### PR TITLE
Remove PF2 restriction

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,6 +1,6 @@
 {
     "name": "combat-tracker-images",
-    "title": "PF2e Combat Tracker Images",
+    "title": "Combat Tracker Images",
     "description": "Replace the token images in the combat tracker with a specified image for each described actor.",
     "author": "Mark Pearce",
     "version": "1.0.1",

--- a/module.json
+++ b/module.json
@@ -6,7 +6,6 @@
     "version": "1.0.1",
     "minimumCoreVersion": "9.0",
     "compatibleCoreVersion": "9.0",
-    "system": ["pf2e"],
     "esmodules": [
         "scripts/init.js"
     ],


### PR DESCRIPTION
I just tested it with the system I am running (Splittermond) and it works flawlessly if you remove the dependency for PF2.

Maybe remove it alltogether? If you don't want to, I can test some systems and give you a list instead.